### PR TITLE
Update remove event listener

### DIFF
--- a/src/utils/useDimensions.ts
+++ b/src/utils/useDimensions.ts
@@ -9,9 +9,9 @@ export function useDimensions() {
   };
 
   useEffect(() => {
-    Dimensions.addEventListener("change", onChange);
+    const EventListener = Dimensions.addEventListener("change", onChange);
 
-    return () => Dimensions.removeEventListener("change", onChange);
+    return EventListener.remove();
   }, []);
 
   return dimensions;


### PR DESCRIPTION
Pull request fixes issue [#99](https://github.com/arnnis/react-native-toast-notifications/issues/99) for React Native 0.65+ and updates removing event listener to new syntax.

I understand if this can't be merged right away, but it would be appreciated if this PR could be merged as soon as Expo SDK supports this.