### PR TITLE
Add elevation style for proper Android rendering

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -163,6 +163,7 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: "100%",
     zIndex: 999999,
+    elevation: 999999,
     left: 0,
     right: 0,
     ...(Platform.OS === "web" ? { overflow: "hidden" } : null),


### PR DESCRIPTION
Before, `Toast` (default export), had to be defined at the bottom of the navigation tree to work properly on Android devices.
This fixes it, you can add it where ever you want to.

Tested in example app & my app.
P.S. - using default export because we have to support the way of rendering toasts inside class components.