### PR TITLE
toast-container won't affect components to the side of the toast

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -159,11 +159,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 0,
     position: "absolute",
-    width: "100%",
     maxWidth: "100%",
     zIndex: 999999,
-    left: 0,
-    right: 0,
+    alignSelf: 'center',
     ...(Platform.OS === "web" ? { overflow: "hidden" } : null),
   },
   message: {


### PR DESCRIPTION
The previous version with right: 0 and left: 0 were causing other components to be unclickable as experience by me and #103 