### PR TITLE
fixed typescript error with toastprovider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-toast-notifications",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -14,6 +14,7 @@ export interface Props extends ToastOptions {
   offsetTop?: number;
   offsetBottom?: number;
   swipeEnabled?: boolean;
+  children?: React.ReactNode;
 }
 
 interface State {


### PR DESCRIPTION
Recieved `Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & Props'.` when using the `ToastProvider` as  so:
```
    <ToastProvider>
      <AppCore />
    </ToastProvider>
```

Based on some reading I did, the error means that the parent component, `ToastProvider` in this case doesn't have `children` added to the props type, so I added it and opened this PR
