### PR TITLE
feat: updateId to allow animation reset

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -74,7 +74,14 @@ class ToastContainer extends Component<Props, State> {
   ) => {
     this.setState({
       toasts: this.state.toasts.map((toast) =>
-        toast.id === id ? { ...toast, message, ...toastOptions } : toast
+        toast.id === id
+          ? {
+              ...toast,
+              message,
+              ...toastOptions,
+              updateId: (Math.random() * 10).toString(),
+            }
+          : toast
       ),
     });
   };

--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -70,7 +70,8 @@ class ToastContainer extends Component<Props, State> {
   update = (
     id: string,
     message: string | JSX.Element,
-    toastOptions?: ToastOptions
+    toastOptions?: ToastOptions,
+    resetAnimation = false
   ) => {
     this.setState({
       toasts: this.state.toasts.map((toast) =>
@@ -79,7 +80,9 @@ class ToastContainer extends Component<Props, State> {
               ...toast,
               message,
               ...toastOptions,
-              updateId: (Math.random() * 10).toString(),
+              updateId: resetAnimation
+                ? (Math.random() * 10).toString()
+                : undefined,
             }
           : toast
       ),

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -111,6 +111,11 @@ export interface ToastOptions {
    */
   data?: any;
 
+  /**
+   * Optional id to reset duration of the toast after an update is done
+   */
+  updateId?: string;
+
   swipeEnabled?: boolean;
 }
 
@@ -134,6 +139,7 @@ const Toast: FC<ToastProps> = (props) => {
     duration = 5000,
     style,
     textStyle,
+    updateId,
     animationDuration = 250,
     animationType = "slide-in",
     successIcon,
@@ -171,6 +177,22 @@ const Toast: FC<ToastProps> = (props) => {
       closeTimeoutRef.current && clearTimeout(closeTimeoutRef.current);
     };
   }, []);
+
+  /**
+   * On every update, changing the updateId will reset the animation
+   */
+  useEffect(() => {
+    if (updateId && closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = setTimeout(() => {
+        handleClose();
+      }, duration);
+    }
+
+    return () => {
+      closeTimeoutRef.current && clearTimeout(closeTimeoutRef.current);
+    };
+  }, [updateId]);
 
   // Handles hide & hideAll
   useEffect(() => {


### PR DESCRIPTION
At the moment, after `toast.update` the Toast will hide depending on the initial duration set.

By adding a `updateId` on `toast.update` the toast component will reset the animation.