### PR TITLE
Fix button inside toast not clickable on Android

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -209,10 +209,14 @@ const Toast: FC<ToastProps> = (props) => {
 
   const getPanResponder = () => {
     if (panResponderRef.current) return panResponderRef.current;
+    const swipeThreshold = Platform.OS === "android" ? 10 : 0;
     panResponderRef.current = PanResponder.create({
       onMoveShouldSetPanResponder: (_, gestureState) => {
         //return true if user is swiping, return false if it's a single click
-        return !(gestureState.dx === 0 && gestureState.dy === 0);
+        return (
+          Math.abs(gestureState.dx) > swipeThreshold ||
+          Math.abs(gestureState.dy) > swipeThreshold
+        );
       },
       onPanResponderMove: (_, gestureState) => {
         getPanResponderAnim()?.setValue({


### PR DESCRIPTION
Fix pan responder evaluating clicks as swipes on Android which prevents buttons inside toasts to be clicked.

Fixes https://github.com/arnnis/react-native-toast-notifications/issues/152