### PR TITLE
fix pointer events

### DIFF
--- a/src/toast-container.tsx
+++ b/src/toast-container.tsx
@@ -122,7 +122,7 @@ class ToastContainer extends Component<Props, State> {
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
         style={[styles.container, style]}
-        pointerEvents="box-none"
+        pointerEvents="none"
       >
         {toasts
           .filter((t) => !t.placement || t.placement === "bottom")
@@ -146,7 +146,7 @@ class ToastContainer extends Component<Props, State> {
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
         style={[styles.container, style]}
-        pointerEvents="box-none"
+        pointerEvents="none"
       >
         {toasts
           .filter((t) => t.placement === "top")
@@ -177,7 +177,7 @@ class ToastContainer extends Component<Props, State> {
       <KeyboardAvoidingView
         behavior={Platform.OS === "ios" ? "position" : undefined}
         style={[styles.container, style]}
-        pointerEvents="box-none"
+        pointerEvents="none"
       >
         {toasts
           .filter((t) => t.placement === "center")

--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -313,6 +313,7 @@ const Toast: FC<ToastProps> = (props) => {
       ref={containerRef}
       {...(swipeEnabled ? getPanResponder().panHandlers : null)}
       style={[styles.container, animationStyle]}
+      pointerEvents="box-none"
     >
       {props.renderType && props.renderType[type] ? (
         props.renderType[type](props)


### PR DESCRIPTION
This fixes #147.
I tried the solution proposed in #148, but it didn't work for me.
I believe the issue here is that the toast-container has `box-none` pointer events, so all of the direct children get `auto`. Since the Animated View inside has `width: 100%`, this setting doesn't really do anything in the end.