### PR TITLE
Fix pointer events side of toast

### DIFF
--- a/src/toast.tsx
+++ b/src/toast.tsx
@@ -310,6 +310,7 @@ const Toast: FC<ToastProps> = (props) => {
 
   return (
     <Animated.View
+      pointerEvents={"box-none"}
       ref={containerRef}
       {...(swipeEnabled ? getPanResponder().panHandlers : null)}
       style={[styles.container, animationStyle]}


### PR DESCRIPTION
Animated view will ignore pointer events, hence making it possible to press next to the toast without experiencing it to block. 
Fixes #147. Have tried fixes #148, #165, but they create other issues. The Toast container need to take full width to be able to align it horizontally. And the other ignores event on the custom toast that I use so I cannot add any buttons on it.